### PR TITLE
Log-in with password

### DIFF
--- a/alburnum/maas/flesh/__init__.py
+++ b/alburnum/maas/flesh/__init__.py
@@ -161,7 +161,8 @@ class cmd_login_base(Command):
             '-k', '--insecure', action='store_true', help=(
                 "Disable SSL certificate check"), default=False)
 
-    def save_profile(self, options, credentials):
+    @staticmethod
+    def save_profile(options, credentials: Credentials):
         # Check for bogus credentials. Do this early so that the user is not
         # surprised when next invoking the MAAS CLI.
         if credentials is not None:

--- a/alburnum/maas/flesh/__init__.py
+++ b/alburnum/maas/flesh/__init__.py
@@ -208,10 +208,11 @@ class cmd_login_base(Command):
 
 
 class cmd_login(cmd_login_base):
-    """Log in to a remote MAAS with username and password.
+    """Log-in to a remote MAAS with username and password.
 
-    If credentials are not provided on the command-line, they will be prompted
-    for interactively.
+    The username and password will NOT be saved; a new API key will be
+    obtained from MAAS and associated with the new profile. This key can be
+    selectively revoked from the Web UI, for example, at a later date.
     """
 
     def __init__(self, parser):
@@ -224,9 +225,9 @@ class cmd_login(cmd_login_base):
             "password", nargs="?", default=None, help=(
                 "The password used to login to MAAS. Omit both the username "
                 "and the password for anonymous API access, or pass a single "
-                "hyphen to allow the password to be provided via stdin. If a "
-                "username is provided but no password, you will be prompted "
-                "interactively for it."
+                "hyphen to allow the password to be provided via standard-"
+                "input. If a username is provided but no password, the "
+                "password will be prompted for, interactively."
             ),
         )
 
@@ -273,22 +274,22 @@ class cmd_login(cmd_login_base):
 
 
 class cmd_login_api(cmd_login_base):
-    """Log in to a remote MAAS with an *API key*.
-
-    If credentials are not provided on the command-line, they will be prompted
-    for interactively.
-    """
+    """Log-in to a remote MAAS with an *API key*."""
 
     def __init__(self, parser):
         super(cmd_login_api, self).__init__(parser)
         parser.add_argument(
             "credentials", nargs="?", default=None, help=(
-                "The credentials, also known as the API key, for the "
-                "remote MAAS server. These can be found in the user "
-                "preferences page in the web UI; they take the form of "
-                "a long random-looking string composed of three parts, "
-                "separated by colons."
-                ))
+                "The credentials, also known as the API key, for the remote "
+                "MAAS server. These can be found in the user preferences page "
+                "in the Web UI; they take the form of a long random-looking "
+                "string composed of three parts, separated by colons. Specify "
+                "an empty string for anonymous API access, or pass a single "
+                "hyphen to allow the credentials to be provided via standard-"
+                "input. If no credentials are provided, they will be prompted "
+                "for, interactively."
+            ),
+        )
 
     def __call__(self, options):
         # Try and obtain credentials interactively if they're not given, or
@@ -300,7 +301,7 @@ class cmd_login_api(cmd_login_base):
 
 
 class cmd_logout(Command):
-    """Log out of a remote API, purging any stored credentials.
+    """Log-out of a remote API, purging any stored credentials.
 
     This will remove the given profile from your command-line  client.  You
     can re-create it by logging in again later.

--- a/alburnum/maas/flesh/__init__.py
+++ b/alburnum/maas/flesh/__init__.py
@@ -15,6 +15,7 @@ from os import environ
 import sys
 from textwrap import fill
 from time import sleep
+from urllib.parse import urlparse
 
 from alburnum.maas import (
     bones,
@@ -22,7 +23,11 @@ from alburnum.maas import (
     viscera,
 )
 from alburnum.maas.bones import CallError
-from alburnum.maas.utils.auth import obtain_credentials
+from alburnum.maas.utils.auth import (
+    obtain_credentials,
+    obtain_password,
+    obtain_token,
+)
 from alburnum.maas.utils.creds import Credentials
 import argcomplete
 import colorclass
@@ -138,15 +143,10 @@ class TableCommand(Command):
         )
 
 
-class cmd_login(Command):
-    """Log in to a remote API, and remember its description and credentials.
-
-    If credentials are not provided on the command-line, they will be prompted
-    for interactively.
-    """
+class cmd_login_base(Command):
 
     def __init__(self, parser):
-        super(cmd_login, self).__init__(parser)
+        super(cmd_login_base, self).__init__(parser)
         parser.add_argument(
             "profile_name", metavar="profile-name", help=(
                 "The name with which you will later refer to this remote "
@@ -158,22 +158,10 @@ class cmd_login(Command):
                 "or http://example.com/MAAS/api/1.0/ if you wish to specify "
                 "the API version."))
         parser.add_argument(
-            "credentials", nargs="?", default=None, help=(
-                "The credentials, also known as the API key, for the "
-                "remote MAAS server. These can be found in the user "
-                "preferences page in the web UI; they take the form of "
-                "a long random-looking string composed of three parts, "
-                "separated by colons."
-                ))
-        parser.add_argument(
             '-k', '--insecure', action='store_true', help=(
                 "Disable SSL certificate check"), default=False)
-        parser.set_defaults(credentials=None)
 
-    def __call__(self, options):
-        # Try and obtain credentials interactively if they're not given, or
-        # read them from stdin if they're specified as "-".
-        credentials = obtain_credentials(options.credentials)
+    def save_profile(self, options, credentials):
         # Check for bogus credentials. Do this early so that the user is not
         # surprised when next invoking the MAAS CLI.
         if credentials is not None:
@@ -185,9 +173,11 @@ class cmd_login(Command):
             else:
                 if not valid_apikey:
                     raise SystemExit("The MAAS server rejected your API key.")
+
         # Establish a session with the remote API.
         session = bones.SessionAPI.fromURL(
             options.url, credentials=credentials, insecure=options.insecure)
+
         # Save the config.
         profile_name = options.profile_name
         with utils.ProfileConfig.open() as config:
@@ -198,22 +188,115 @@ class cmd_login(Command):
                 "url": options.url,
                 }
             profile = config[profile_name]
-        self.print_whats_next(profile)
+
+        return profile
 
     @staticmethod
     def print_whats_next(profile):
         """Explain what to do next."""
         what_next = [
-            "You are now logged in to the MAAS server at {url} "
-            "with the profile name '{name}'.",
+            "{{autogreen}}Congratulations!{{/autogreen}} You are logged in "
+            "to the MAAS server at {{autoblue}}{url}{{/autoblue}} with the "
+            "profile name {{autoblue}}{name}{{/autoblue}}.",
             "For help with the available commands, try:",
             "  maas --help",
             ]
-        print()
         for message in what_next:
             message = message.format(**profile)
-            print(fill(message))
+            print(colorized(fill(message)))
             print()
+
+
+class cmd_login(cmd_login_base):
+    """Log in to a remote MAAS with username and password.
+
+    If credentials are not provided on the command-line, they will be prompted
+    for interactively.
+    """
+
+    def __init__(self, parser):
+        super(cmd_login, self).__init__(parser)
+        parser.add_argument(
+            "username", nargs="?", default=None, help=(
+                "The username used to login to MAAS. Omit this and the "
+                "password for anonymous API access."))
+        parser.add_argument(
+            "password", nargs="?", default=None, help=(
+                "The password used to login to MAAS. Omit both the username "
+                "and the password for anonymous API access, or pass a single "
+                "hyphen to allow the password to be provided via stdin. If a "
+                "username is provided but no password, you will be prompted "
+                "interactively for it."
+            ),
+        )
+
+    def __call__(self, options):
+        url = urlparse(options.url)
+
+        if options.username is None:
+            username = url.username
+        else:
+            if url.username is None or len(url.username) == 0:
+                username = options.username
+            else:
+                raise CommandError(
+                    "Username provided on command-line (%r) and in URL (%r); "
+                    "provide only one." % (options.username, url.username))
+
+        if options.password is None:
+            password = url.password
+        else:
+            if url.password is None or len(url.password) == 0:
+                password = options.password
+            else:
+                raise CommandError(
+                    "Password provided on command-line (%r) and in URL (%r); "
+                    "provide only one." % (options.password, url.password))
+
+        if username is None:
+            if password is None or len(password) == 0:
+                credentials = None  # Anonymous.
+            else:
+                raise CommandError(
+                    "Password provided without username; specify username.")
+        else:
+            password = obtain_password(password)
+            if password is None:
+                raise CommandError("No password supplied.")
+            else:
+                credentials = obtain_token(
+                    options.url, username, password)
+
+        # Save a new profile, and print something useful.
+        profile = self.save_profile(options, credentials)
+        self.print_whats_next(profile)
+
+
+class cmd_login_api(cmd_login_base):
+    """Log in to a remote MAAS with an *API key*.
+
+    If credentials are not provided on the command-line, they will be prompted
+    for interactively.
+    """
+
+    def __init__(self, parser):
+        super(cmd_login_api, self).__init__(parser)
+        parser.add_argument(
+            "credentials", nargs="?", default=None, help=(
+                "The credentials, also known as the API key, for the "
+                "remote MAAS server. These can be found in the user "
+                "preferences page in the web UI; they take the form of "
+                "a long random-looking string composed of three parts, "
+                "separated by colons."
+                ))
+
+    def __call__(self, options):
+        # Try and obtain credentials interactively if they're not given, or
+        # read them from stdin if they're specified as "-".
+        credentials = obtain_credentials(options.credentials)
+        # Save a new profile, and print something useful.
+        profile = self.save_profile(options, credentials)
+        self.print_whats_next(profile)
 
 
 class cmd_logout(Command):
@@ -429,6 +512,7 @@ def prepare_parser(argv):
 
     # Basic commands.
     cmd_login.register(parser)
+    cmd_login_api.register(parser)
     cmd_logout.register(parser)
     cmd_list_profiles.register(parser)
     cmd_refresh_profiles.register(parser)

--- a/alburnum/maas/flesh/tests/test_flesh.py
+++ b/alburnum/maas/flesh/tests/test_flesh.py
@@ -2,7 +2,7 @@
 # This software is licensed under the GNU Affero General Public
 # License version 3 (see LICENSE).
 
-"""Tests for `alburnum.maas.viscera`."""
+"""Tests for `alburnum.maas.flesh`."""
 
 __all__ = []
 
@@ -19,30 +19,17 @@ from alburnum.maas.utils import auth
 from alburnum.maas.utils.tests.test_auth import make_options
 
 
-class TestLogin(TestCase):
-
-    def test_cmd_login_ensures_valid_apikey(self):
-        parser = flesh.ArgumentParser()
-        options = make_options()
-        check_key = self.patch(flesh, "check_valid_apikey")
-        check_key.return_value = False
-        login = flesh.cmd_login(parser)
-        error = self.assertRaises(SystemExit, login, options)
-        self.assertEqual(
-            "The MAAS server rejected your API key.",
-            str(error))
-        check_key.assert_called_once_with(
-            options.url, auth.Credentials.parse(options.credentials),
-            options.insecure)
+class TestLoginBase(TestCase):
+    """Tests for `cmd_login_base`."""
 
     def test_print_whats_next(self):
         profile = {"name": make_name("profile"), "url": make_name("url")}
         stdout = self.patch(sys, "stdout", StringIO())
-        flesh.cmd_login.print_whats_next(profile)
+        flesh.cmd_login_base.print_whats_next(profile)
         expected = dedent("""\
-
-            You are now logged in to the MAAS server at %(url)s with the
-            profile name '%(name)s'.
+            Congratulations! You are logged in to the MAAS
+            server at %(url)s with the profile name
+            %(name)s.
 
             For help with the available commands, try:
 
@@ -51,3 +38,17 @@ class TestLogin(TestCase):
             """) % profile
         observed = stdout.getvalue()
         self.assertDocTestMatches(expected, observed)
+
+    def test_save_profile_ensures_valid_apikey(self):
+        options = make_options()
+        check_key = self.patch(flesh, "check_valid_apikey")
+        check_key.return_value = False
+        error = self.assertRaises(
+            SystemExit, flesh.cmd_login_base.save_profile, options,
+            auth.Credentials.parse(options.credentials))
+        self.assertEqual(
+            "The MAAS server rejected your API key.",
+            str(error))
+        check_key.assert_called_once_with(
+            options.url, auth.Credentials.parse(options.credentials),
+            options.insecure)

--- a/alburnum/maas/skin.py
+++ b/alburnum/maas/skin.py
@@ -169,7 +169,7 @@ class Shell(cmd.Cmd, metaclass=ShellType):
     #
 
     def do_login(self, text):
-        """Log in to a remote API, and remember its details.
+        """Log-in to a remote API, and remember its details.
 
         If credentials are not provided on the command-line, they will be
         prompted for interactively.

--- a/alburnum/maas/utils/auth.py
+++ b/alburnum/maas/utils/auth.py
@@ -5,13 +5,22 @@
 """MAAS CLI authentication."""
 
 __all__ = [
-    'obtain_credentials',
+    "obtain_credentials",
+    "obtain_password",
+    "obtain_token",
     ]
 
-from getpass import getpass
+from getpass import (
+    getpass,
+    getuser,
+)
+from socket import gethostname
 import sys
+from urllib.parse import urljoin
 
 from alburnum.maas.utils.creds import Credentials
+import bs4
+import requests
 
 
 def try_getpass(prompt):
@@ -38,3 +47,64 @@ def obtain_credentials(credentials):
         return Credentials.parse(credentials)
     else:
         return None
+
+
+def obtain_password(password):
+    """Prompt for password if possible.
+
+    If the password is "-" then read from stdin without interactive prompting.
+    """
+    if password == "-":
+        return sys.stdin.readline().strip()
+    elif password is None:
+        return try_getpass("Password: ")
+    else:
+        return password
+
+
+def obtain_token(url, username, password):
+    """Obtain a new API key by logging into MAAS.
+
+    :return: A `Credentials` instance.
+    """
+    url_login = urljoin(url, "../../accounts/login/")
+    url_token = urljoin(url, "account/")
+
+    with requests.Session() as session:
+
+        # Fetch the log-in page.
+        response = session.get(url_login)
+        response.raise_for_status()
+
+        # Extract the CSRF token.
+        login_doc = bs4.BeautifulSoup(response.content, "html.parser")
+        login = login_doc.find('form', {"class": "login"})
+        login_data = {
+            elem["name"]: elem["value"] for elem in login("input")
+            if elem.has_attr("name") and elem.has_attr("value")
+        }
+        login_data["username"] = username
+        login_data["password"] = password
+        # The following `requester` field is not used (at the time of
+        # writing) but it ought to be associated with this new token so
+        # that tokens can be selectively revoked a later date.
+        login_data["requester"] = "%s@%s" % (getuser(), gethostname())
+
+        # Log-in to MAAS.
+        response = session.post(url_login, login_data)
+        response.raise_for_status()
+
+        # Request a new API token.
+        response = session.post(
+            url_token, {"op": "create_authorisation_token"},
+            headers={"Accept": "application/json"},
+        )
+        response.raise_for_status()
+
+        # We have it!
+        token = response.json()
+        return Credentials(
+            token["consumer_key"],
+            token["token_key"],
+            token["token_secret"],
+        )

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,12 @@ setup(
     },
     install_requires={
         "argcomplete >= 1.0",
+        "beautifulsoup4 >= 4.4.1",
         "colorclass >= 1.2.0",
         "httplib2 >= 0.8",
         "oauthlib >= 1.0.3",
         "PyYAML >= 3.11",
+        "requests >= 2.9.1",
         "terminaltables >= 2.1.0",
     },
     test_suite="alburnum.maas",


### PR DESCRIPTION
Make the default way to log-in to MAAS be via username/password instead of by specifying an API key.