### PR TITLE
Remove copyright headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# mkdocs
+site/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 PYTHON := python3.5
 
 # ---

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ clean:
 README: README.md
 	pandoc --from markdown --to rst --output $@ $^
 
+docs: bin/mkdocs
+	bin/mkdocs build --config-file doc.yaml --clean --strict
+
 # ---
 
 bin/tox: bin/pip
@@ -39,6 +42,9 @@ bin/tox: bin/pip
 bin/python bin/pip:
 	virtualenv --python=$(PYTHON) --quiet $(CURDIR)
 
+bin/mkdocs: bin/pip
+	bin/pip install --quiet --ignore-installed "mkdocs >= 0.14.0"
+
 # ---
 
-.PHONY: develop dist test clean
+.PHONY: develop dist docs test clean

--- a/README
+++ b/README
@@ -10,6 +10,12 @@ the GNU Affero GPLv3 too, the same as MAAS itself.
 
 |Build Status| |codecov.io|
 
+This package was begun by Alburnum Ltd, and some of it has come from
+`MAAS itself <https://code.launchpad.net/~maas-committers/maas/trunk>`__
+upon which Canonical Ltd have the copyright. However, Alburnum Ltd
+licenses its parts under the AGPLv3, and MAAS is also under the AGPLv3,
+so everything should be good.
+
 Dependencies
 ------------
 

--- a/README
+++ b/README
@@ -38,35 +38,32 @@ the MAAS:
     import httplib
     from pprint import pprint
 
-    from alburnum.maas.client import (
-        CallError,
-        SessionAPI,
-    )
+    from alburnum.maas import bones
 
     # Load a MAAS CLI profile. The name below (here "madagascar") should be the
     # name of a profile created when using `maas login` at the command-line.
-    papi = SessionAPI.fromProfileName("madagascar")
+    session = bones.SessionAPI.fromProfileName(options.profile)
 
     # Create a tag if it doesn't exist.
     tag_name = "foo"
     try:
-        tag = papi.Tag.read(name=tag_name)
-    except CallError as error:
-        if error.status == httplib.NOT_FOUND:
-            tag = papi.Tags.new(
+        tag = session.Tag.read(name=tag_name)
+    except bones.CallError as error:
+        if error.status == HTTPStatus.NOT_FOUND:
+            tag = session.Tags.new(
                 name=tag_name, comment="%s's Stuff" % tag_name.capitalize())
         else:
             raise
 
     # List all the MAAS's tags.
     print(" Tags.list() ".center(50, "="))
-    pprint(papi.Tags.list())
+    pprint(session.Tags.list())
 
     # Associate the tag with all nodes.
     print(" Tag.update_nodes() ".center(50, "="))
-    pprint(papi.Tag.update_nodes(
+    pprint(session.Tag.update_nodes(
         name=tag["name"], add=[
-            node["system_id"] for node in papi.Nodes.list()
+            node["system_id"] for node in session.Nodes.list()
         ]))
 
 .. |Build Status| image:: https://travis-ci.org/alburnum/alburnum-maas-client.svg?branch=master

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ the GNU Affero GPLv3 too, the same as MAAS itself.
 [![Build Status](https://travis-ci.org/alburnum/alburnum-maas-client.svg?branch=master)](https://travis-ci.org/alburnum/alburnum-maas-client)
 [![codecov.io](https://codecov.io/github/alburnum/alburnum-maas-client/coverage.svg?branch=master)](https://codecov.io/github/alburnum/alburnum-maas-client?branch=master)
 
+This package was begun by Alburnum Ltd, and some of it has come from
+[MAAS itself](https://code.launchpad.net/~maas-committers/maas/trunk)
+upon which Canonical Ltd have the copyright. However, Alburnum Ltd
+licenses its parts under the AGPLv3, and MAAS is also under the AGPLv3,
+so everything should be good.
+
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -32,35 +32,32 @@ the MAAS:
 import httplib
 from pprint import pprint
 
-from alburnum.maas.client import (
-    CallError,
-    SessionAPI,
-)
+from alburnum.maas import bones
 
 # Load a MAAS CLI profile. The name below (here "madagascar") should be the
 # name of a profile created when using `maas login` at the command-line.
-papi = SessionAPI.fromProfileName("madagascar")
+session = bones.SessionAPI.fromProfileName(options.profile)
 
 # Create a tag if it doesn't exist.
 tag_name = "foo"
 try:
-    tag = papi.Tag.read(name=tag_name)
-except CallError as error:
-    if error.status == httplib.NOT_FOUND:
-        tag = papi.Tags.new(
+    tag = session.Tag.read(name=tag_name)
+except bones.CallError as error:
+    if error.status == HTTPStatus.NOT_FOUND:
+        tag = session.Tags.new(
             name=tag_name, comment="%s's Stuff" % tag_name.capitalize())
     else:
         raise
 
 # List all the MAAS's tags.
 print(" Tags.list() ".center(50, "="))
-pprint(papi.Tags.list())
+pprint(session.Tags.list())
 
 # Associate the tag with all nodes.
 print(" Tag.update_nodes() ".center(50, "="))
-pprint(papi.Tag.update_nodes(
+pprint(session.Tag.update_nodes(
     name=tag["name"], add=[
-        node["system_id"] for node in papi.Nodes.list()
+        node["system_id"] for node in session.Nodes.list()
     ]))
 ```
 

--- a/alburnum/maas/bones/__init__.py
+++ b/alburnum/maas/bones/__init__.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Interact with a remote MAAS (https://maas.ubuntu.com/).
 
 These are low-level bindings that closely mirror the shape of MAAS's Web API,

--- a/alburnum/maas/bones/tests/test_bones.py
+++ b/alburnum/maas/bones/tests/test_bones.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Tests for `alburnum.maas.client`."""
 
 __all__ = []

--- a/alburnum/maas/flesh/__init__.py
+++ b/alburnum/maas/flesh/__init__.py
@@ -1,7 +1,3 @@
-# Copyright 2012-2015 Canonical Ltd. Copyright 2015 Alburnum Ltd.
-# This software is licensed under the GNU Affero General Public
-# License version 3 (see LICENSE).
-
 """Commands for interacting with a remote MAAS."""
 
 __all__ = []

--- a/alburnum/maas/flesh/tables.py
+++ b/alburnum/maas/flesh/tables.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Tables for representing information from MAAS."""
 
 __all__ = [

--- a/alburnum/maas/flesh/tabular.py
+++ b/alburnum/maas/flesh/tabular.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Helpers to assemble and render tabular data."""
 
 __all__ = [

--- a/alburnum/maas/flesh/tests/test_flesh.py
+++ b/alburnum/maas/flesh/tests/test_flesh.py
@@ -1,7 +1,3 @@
-# Copyright 2012-2015 Canonical Ltd. Copyright 2015 Alburnum Ltd.
-# This software is licensed under the GNU Affero General Public
-# License version 3 (see LICENSE).
-
 """Tests for `alburnum.maas.flesh`."""
 
 __all__ = []

--- a/alburnum/maas/skin.py
+++ b/alburnum/maas/skin.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Shell for interacting with a remote MAAS (https://maas.ubuntu.com/)."""
 
 __all__ = [

--- a/alburnum/maas/testing.py
+++ b/alburnum/maas/testing.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Testing framework for `alburnum.maas`."""
 
 __all__ = [

--- a/alburnum/maas/utils/__init__.py
+++ b/alburnum/maas/utils/__init__.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Utilities for the Alburnum MAAS client."""
 
 __all__ = [

--- a/alburnum/maas/utils/auth.py
+++ b/alburnum/maas/utils/auth.py
@@ -1,7 +1,3 @@
-# Copyright 2012-2015 Canonical Ltd. Copyright 2015 Alburnum Ltd.
-# This software is licensed under the GNU Affero General Public
-# License version 3 (see the file LICENSE).
-
 """MAAS CLI authentication."""
 
 __all__ = [

--- a/alburnum/maas/utils/creds.py
+++ b/alburnum/maas/utils/creds.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Handling of MAAS API credentials.
 
 The API client deals with credentials consisting of 3 elements: consumer key,

--- a/alburnum/maas/utils/multipart.py
+++ b/alburnum/maas/utils/multipart.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Encoding of MIME multipart data."""
 
 __all__ = [

--- a/alburnum/maas/utils/tests/test_auth.py
+++ b/alburnum/maas/utils/tests/test_auth.py
@@ -1,7 +1,3 @@
-# Copyright 2012-2015 Canonical Ltd. Copyright 2015 Alburnum Ltd.
-# This software is licensed under the GNU Affero General Public
-# License version 3 (see the file LICENSE).
-
 """Tests for `alburnum.maas.auth`."""
 
 __all__ = []

--- a/alburnum/maas/utils/tests/test_creds.py
+++ b/alburnum/maas/utils/tests/test_creds.py
@@ -1,7 +1,3 @@
-# Copyright 2012-2015 Canonical Ltd. Copyright 2015 Alburnum Ltd.
-# This software is licensed under the GNU Affero General Public
-# License version 3 (see the file LICENSE).
-
 """Tests for handling of MAAS API credentials."""
 
 __all__ = []

--- a/alburnum/maas/utils/tests/test_multipart.py
+++ b/alburnum/maas/utils/tests/test_multipart.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Test multipart MIME helpers."""
 
 __all__ = []

--- a/alburnum/maas/utils/tests/test_utils.py
+++ b/alburnum/maas/utils/tests/test_utils.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Tests for `alburnum.maas.utils`."""
 
 __all__ = []

--- a/alburnum/maas/viscera/__init__.py
+++ b/alburnum/maas/viscera/__init__.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Interact with a remote MAAS (https://maas.ubuntu.com/).
 
 These are highish-level bindings that provide user-oriented objects to

--- a/doc.yaml
+++ b/doc.yaml
@@ -1,0 +1,10 @@
+docs_dir: doc
+markdown_extensions:
+  - codehilite
+  - sane_lists
+  - smarty
+repo_url: https://github.com/alburnum/alburnum-maas-client
+site_name: MAAS Client Library & CLI
+strict: true
+theme: readthedocs
+use_directory_urls: false

--- a/doc/bones/index.md
+++ b/doc/bones/index.md
@@ -1,0 +1,1 @@
+# _Bones_: Low-level Python client API

--- a/doc/index.md
+++ b/doc/index.md
@@ -17,7 +17,8 @@ There are two client libraries that make use of MAAS's Web API:
   _viscera_ presents a saner API, designed for developers rather than
   machines.
 
-The implementation of _viscera_ makes use of _bones_. _Viscera_ is the
-API that should be preferred for application development.
+The implementation of [_viscera_](viscera/index.md) makes use of
+[_bones_](bones/index.md). _Viscera_ is the API that should be preferred
+for application development.
 
 Next: [Get started with _viscera_](viscera/getting-started.md)

--- a/doc/index.md
+++ b/doc/index.md
@@ -4,6 +4,22 @@ For documentation on the MAAS server components, visit
 [maas.ubuntu.com](https://maas.ubuntu.com/docs/).
 
 
+## Command-line
+
+```console
+$ bin/maas login --help
+$ bin/maas login exmpl http://example.com:5240/MAAS/ my_username
+Password: …
+$ bin/maas list-nodes --profile-name exmpl
+┌───────────────┬───────────┬───────────────┬───────┬────────┬───────────┬───────┐
+│ Hostname      │ System ID │ Architecture  │ #CPUs │ RAM    │ Status    │ Power │
+├───────────────┼───────────┼───────────────┼───────┼────────┼───────────┼───────┤
+│ botswana.maas │ 433334    │ amd64/generic │ 4     │ 8.0 GB │ Ready     │ Off   │
+│ namibia.maas  │ 433333    │ amd64/generic │ 4     │ 8.0 GB │ Allocated │ Off   │
+└───────────────┴───────────┴───────────────┴───────┴────────┴───────────┴───────┘
+```
+
+
 ## Client libraries
 
 There are two client libraries that make use of MAAS's Web API:

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,23 @@
+## Welcome to MAAS's new command-line tool & Python client libraries. ##
+
+For documentation on the MAAS server components, visit
+[maas.ubuntu.com](https://maas.ubuntu.com/docs/).
+
+
+## Client libraries
+
+There are two client libraries that make use of MAAS's Web API:
+
+* A lower-level library that closely mirrors MAAS's Web API, referred to
+  as _bones_. The MAAS server publishes a description of its Web API and
+  _bones_ provides a convenient mechanism to interact with it.
+
+* A higher-level library that's designed for developers, referred to as
+  _viscera_. MAAS's Web API is sometimes unfriendly or inconsistent, but
+  _viscera_ presents a saner API, designed for developers rather than
+  machines.
+
+The implementation of _viscera_ makes use of _bones_. _Viscera_ is the
+API that should be preferred for application development.
+
+Next: [Get started with _viscera_](viscera/getting-started.md)

--- a/doc/viscera/getting-started.md
+++ b/doc/viscera/getting-started.md
@@ -32,9 +32,9 @@ __TODO__: Log-in programmatically.
 
 Then start an interactive Python shell (e.g. `bin/python`):
 
-```python
+```pycon
 >>> from alburnum.maas import bones, viscera
->>> session = bones.Session.fromProfileName("foo")
+>>> session = bones.SessionAPI.fromProfileName("foo")
 >>> origin = viscera.Origin(session)
 ```
 
@@ -52,9 +52,33 @@ $ bin/maas logout foo
 __TODO__: Log-out programmatically.
 
 
-## List nodes
+## Nodes
 
-```python
+Listing nodes:
+
+```pycon
 >>> for node in origin.Nodes:
 ...     print(node)
+```
+
+Acquiring and starting nodes:
+
+```pycon
+>>> help(origin.Nodes.acquire)
+acquire(*, hostname:str=None, architecture:str=None, cpus:int=None,
+        memory:float=None, tags:typing.Sequence=None) method of
+            alburnum.maas.viscera.NodesType instance
+    :param hostname: The hostname to match.
+    :param architecture: The architecture to match, e.g. "amd64".
+    :param cpus: The minimum number of CPUs to match.
+    :param memory: The minimum amount of RAM to match.
+    :param tags: The tags to match, as a sequence. Each tag may be
+        prefixed with a hyphen to denote that the given tag should NOT be
+        associated with a matched node.
+>>> node = origin.Nodes.acquire(tags=("foo", "-bar"))
+>>> print(node.substatus_name)
+Acquired
+>>> node.start()
+>>> print(node.substatus_name)
+Deploying
 ```

--- a/doc/viscera/getting-started.md
+++ b/doc/viscera/getting-started.md
@@ -5,7 +5,7 @@
 
 Either work from a branch:
 
-```sh
+```console
 $ git clone https://github.com/alburnum/alburnum-maas-client.git
 $ cd alburnum-maas-client
 $ make
@@ -13,7 +13,7 @@ $ make
 
 Or install from [PyPI](https://pypi.python.org/):
 
-```sh
+```console
 $ virtualenv --python=python3.5 maas
 $ cd maas
 $ bin/pip install alburnum-maas-client
@@ -23,9 +23,9 @@ $ bin/pip install alburnum-maas-client
 
 Log-in using the command-line tool:
 
-```sh
+```console
 $ bin/maas login foo http://example.com:5240/MAAS/ admin
-Password: ...
+Password: …
 ```
 
 __TODO__: Log-in programmatically.
@@ -45,7 +45,7 @@ The `origin` instance is the root object of the API.
 
 Log-out using the command-line tool:
 
-```sh
+```console
 $ bin/maas logout foo
 ```
 

--- a/doc/viscera/getting-started.md
+++ b/doc/viscera/getting-started.md
@@ -1,0 +1,60 @@
+# Getting started with _viscera_
+
+
+## Installation
+
+Either work from a branch:
+
+```sh
+$ git clone https://github.com/alburnum/alburnum-maas-client.git
+$ cd alburnum-maas-client
+$ make
+```
+
+Or install from [PyPI](https://pypi.python.org/):
+
+```sh
+$ virtualenv --python=python3.5 maas
+$ cd maas
+$ bin/pip install alburnum-maas-client
+```
+
+## Logging-in
+
+Log-in using the command-line tool:
+
+```sh
+$ bin/maas login foo http://example.com:5240/MAAS/ admin
+Password: ...
+```
+
+__TODO__: Log-in programmatically.
+
+Then start an interactive Python shell (e.g. `bin/python`):
+
+```python
+>>> from alburnum.maas import bones, viscera
+>>> session = bones.Session.fromProfileName("foo")
+>>> origin = viscera.Origin(session)
+```
+
+The `origin` instance is the root object of the API.
+
+
+## Logging out
+
+Log-out using the command-line tool:
+
+```sh
+$ bin/maas logout foo
+```
+
+__TODO__: Log-out programmatically.
+
+
+## List nodes
+
+```python
+>>> for node in origin.Nodes:
+...     print(node)
+```

--- a/doc/viscera/index.md
+++ b/doc/viscera/index.md
@@ -1,0 +1,1 @@
+# _Viscera_: High-level Python client API

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
-
 """Setuptools installer for alburnum-maas-client."""
 
 from setuptools import (

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,12 @@ setup(
     author='Gavin Panella',
     author_email='gavinpanella@gmail.com',
     url='https://github.com/alburnum/alburnum-maas-client',
-    version="0.3.0",
+    version="0.3.1",
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: GNU Affero General Public License v3',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Libraries',

--- a/tryit.py
+++ b/tryit.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3.5
-# Copyright 2015 Alburnum Ltd. This software is licensed under
-# the GNU Affero General Public License version 3 (see LICENSE).
 
 from argparse import ArgumentParser
 from http import HTTPStatus


### PR DESCRIPTION
They're annoying and need maintenance for no obviously useful reason. A file named LICENSE is included in the source tree, and the package metadata declares the license.