### PR TITLE
Update Machine/Machines to use allocate/deploy instead of acquire/start

### DIFF
--- a/alburnum/maas/viscera/machines.py
+++ b/alburnum/maas/viscera/machines.py
@@ -35,7 +35,7 @@ class MachinesType(ObjectType):
     def read(cls):
         return cls(cls)
 
-    def acquire(
+    def allocate(
             cls, *, hostname: str=None, architecture: str=None,
             cpus: int=None, memory: float=None, tags: Sequence[str]=None):
         """
@@ -63,7 +63,7 @@ class MachinesType(ObjectType):
                 tag[1:] for tag in tags if tag.startswith("-")]
 
         try:
-            data = cls._handler.acquire(**params)
+            data = cls._handler.allocate(**params)
         except CallError as error:
             if error.status == HTTPStatus.CONFLICT:
                 message = "No machine matching the given criteria was found."
@@ -153,10 +153,10 @@ class Machine(Object, metaclass=MachineType):
     zone = zones.ZoneField(
         "zone", readonly=True)
 
-    def start(
+    def deploy(
             self, user_data: Union[bytes, str]=None, distro_series: str=None,
             hwe_kernel: str=None, comment: str=None):
-        """Start this machine.
+        """Deploy this machine.
 
         :param user_data: User-data to provide to the machine when booting. If
             provided as a byte string, it will be base-64 encoded prior to
@@ -181,7 +181,7 @@ class Machine(Object, metaclass=MachineType):
             params["hwe_kernel"] = hwe_kernel
         if comment is not None:
             params["comment"] = comment
-        data = self._handler.start(**params)
+        data = self._handler.deploy(**params)
         return type(self)(data)
 
     def release(self, comment: str=None):

--- a/alburnum/maas/viscera/testing.py
+++ b/alburnum/maas/viscera/testing.py
@@ -1,0 +1,12 @@
+""" Testing framework for alburnum.maas.viscera """
+
+__all__ = ['bind']
+
+from unittest.mock import MagicMock
+
+
+def bind(cls, origin=None, handler=None):
+    return cls.bind(
+        (MagicMock() if origin is None else origin),
+        (MagicMock() if handler is None else handler),
+    )

--- a/alburnum/maas/viscera/testing.py
+++ b/alburnum/maas/viscera/testing.py
@@ -6,6 +6,10 @@ from unittest.mock import MagicMock
 
 
 def bind(cls, origin=None, handler=None):
+    """
+    Returns a new version of the class that binds the origin
+    and handler of that class with MagicMock (unless you specify otherwise)
+    """
     return cls.bind(
         (MagicMock() if origin is None else origin),
         (MagicMock() if handler is None else handler),

--- a/alburnum/maas/viscera/tests/test_events.py
+++ b/alburnum/maas/viscera/tests/test_events.py
@@ -19,19 +19,14 @@ from alburnum.maas.testing import (
     randrange,
     TestCase,
 )
+from alburnum.maas.viscera.testing import bind
+
 from testtools.matchers import (
     Equals,
     IsInstance,
 )
 
 from .. import events
-
-
-def bind(cls, origin=None, handler=None):
-    return cls.bind(
-        (MagicMock() if origin is None else origin),
-        (MagicMock() if handler is None else handler),
-    )
 
 
 event_ids = count(1)

--- a/alburnum/maas/viscera/tests/test_machines.py
+++ b/alburnum/maas/viscera/tests/test_machines.py
@@ -2,10 +2,13 @@
 
 __all__ = []
 
+
 from alburnum.maas.testing import (
     make_name_without_spaces,
     TestCase,
 )
+from alburnum.maas.viscera.testing import bind
+
 from testtools.matchers import Equals
 
 from .. import machines
@@ -21,3 +24,19 @@ class TestMachine(TestCase):
         self.assertThat(repr(machine), Equals(
             "<Machine hostname=%(hostname)r system_id=%(system_id)r>"
             % machine._data))
+
+    def test__deploy(self):
+        Machine = bind(machines.Machine)
+        Machine._handler.deploy.return_value = {}
+        machine = Machine({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+        })
+        machine.deploy()
+        machine._handler.deploy.assert_called_once_with(
+            system_id=machine.system_id
+        )
+
+
+class TestMachines(TestCase):
+    pass

--- a/alburnum/maas/viscera/tests/test_machines.py
+++ b/alburnum/maas/viscera/tests/test_machines.py
@@ -2,9 +2,11 @@
 
 __all__ = []
 
+import base64
 
 from alburnum.maas.testing import (
     make_name_without_spaces,
+    make_string,
     TestCase,
 )
 from alburnum.maas.viscera.testing import bind
@@ -32,11 +34,35 @@ class TestMachine(TestCase):
             "system_id": make_name_without_spaces("system-id"),
             "hostname": make_name_without_spaces("hostname"),
         })
-        machine.deploy()
+        machine.deploy(
+            distro_series='ubuntu/xenial',
+            hwe_kernel='hwe-x',
+        )
         machine._handler.deploy.assert_called_once_with(
-            system_id=machine.system_id
+            system_id=machine.system_id,
+            distro_series='ubuntu/xenial',
+            hwe_kernel='hwe-x',
         )
 
 
 class TestMachines(TestCase):
-    pass
+
+    def test__allocate(self):
+        Machines = bind(machines.Machines)
+        Machines._handler.allocate.return_value = {}
+        hostname = make_name_without_spaces("hostname")
+        Machines.allocate(
+            hostname=hostname,
+            architecture='amd64/generic',
+            cpus=4,
+            memory=1024.0,
+            tags=['foo', 'bar', '-baz'],
+        )
+        Machines._handler.allocate.assert_called_once_with(
+            hostname=hostname,
+            architecture='amd64/generic',
+            cpu_count='4',
+            mem='1024.0',
+            tags=['foo', 'bar'],
+            not_tags=['baz'],
+        )


### PR DESCRIPTION
Attempt to address https://github.com/alburnum/alburnum-maas-client/issues/25. Not 100% sure if this is the right approach, but as least it allows us to allocate and deploy on 2.0