### PR TITLE
Add BootSource python API.

### DIFF
--- a/alburnum/maas/bones/__init__.py
+++ b/alburnum/maas/bones/__init__.py
@@ -407,7 +407,7 @@ class CallAPI:
 
         # Bundle things up ready to throw over the wire.
         uri, body, headers = utils.prepare_payload(
-            self.action.op, self.action.method, self.uri, dict(data))
+            self.action.op, self.action.method, self.uri, data)
 
         # Headers are returned as a list, but they must be a dict for
         # the signing machinery.

--- a/alburnum/maas/bones/__init__.py
+++ b/alburnum/maas/bones/__init__.py
@@ -403,7 +403,7 @@ class CallAPI:
 
         # Bundle things up ready to throw over the wire.
         uri, body, headers = utils.prepare_payload(
-            self.action.op, self.action.method, self.uri, data)
+            self.action.op, self.action.method, self.uri, dict(data))
 
         # Headers are returned as a list, but they must be a dict for
         # the signing machinery.

--- a/alburnum/maas/viscera/__init__.py
+++ b/alburnum/maas/viscera/__init__.py
@@ -25,12 +25,14 @@ from collections import (
     Sequence,
 )
 from copy import copy
+from datetime import datetime
 from functools import wraps
 from importlib import import_module
 from itertools import (
     chain,
     starmap,
 )
+import pytz
 from types import MethodType
 from typing import Optional
 
@@ -498,6 +500,11 @@ def check_optional(expected):
     return check(Optional[expected])
 
 
+def parse_timestamp(created):
+    created = datetime.strptime(created, "%Y-%m-%dT%H:%M:%S.%f")
+    return created.replace(tzinfo=pytz.UTC)
+
+
 #
 # Now it's possible to define the default Origin, which uses a predefined set
 # of specialised objects. Most people should use this.
@@ -576,6 +583,7 @@ class Origin(OriginBase, metaclass=OriginType):
         modules = {
             ".",
             ".account",
+            ".boot_sources",
             ".controllers",
             ".devices",
             ".events",

--- a/alburnum/maas/viscera/boot_sources.py
+++ b/alburnum/maas/viscera/boot_sources.py
@@ -24,9 +24,12 @@ class BootSourcesType(ObjectType):
 
     def create(cls, url, *, keyring_filename=None, keyring_data=None):
         """Create a new `BootSource`."""
-        if keyring_filename is None and keyring_data is None:
+        if (not url.endswith(".json") and
+                keyring_filename is None and
+                keyring_data is None):
             raise ValueError(
-                "Either keyring_filename and keyring_data must be set.")
+                "Either keyring_filename and keyring_data must be set when "
+                "providing a signed source.")
         data = cls._handler.create(
             url=url,
             keyring_filename=(
@@ -68,6 +71,10 @@ class BootSource(Object, metaclass=BootSourceType):
         "created", parse_timestamp, readonly=True)
     updated = ObjectField.Checked(
         "updated", parse_timestamp, readonly=True)
+
+    def __repr__(self):
+        return super(BootSource, self).__repr__(
+            fields={"url", "keyring_filename", "keyring_data"})
 
     def delete(self):
         """Delete boot source."""

--- a/alburnum/maas/viscera/boot_sources.py
+++ b/alburnum/maas/viscera/boot_sources.py
@@ -1,0 +1,74 @@
+"""Objects for boot sources."""
+
+__all__ = [
+    "BootSource",
+    "BootSources",
+]
+
+from . import (
+    check,
+    check_optional,
+    Object,
+    ObjectField,
+    ObjectSet,
+    ObjectType,
+    parse_timestamp,
+)
+
+
+class BootSourcesType(ObjectType):
+    """Metaclass for `BootSources`."""
+
+    def __iter__(cls):
+        return map(cls._object, cls._handler.read())
+
+    def create(cls, url, *, keyring_filename=None, keyring_data=None):
+        """Create a new `BootSource`."""
+        if keyring_filename is None and keyring_data is None:
+            raise ValueError(
+                "Either keyring_filename and keyring_data must be set.")
+        data = cls._handler.create(
+            url=url,
+            keyring_filename=(
+                "" if keyring_filename is None else keyring_filename),
+            keyring_data=(
+                "" if keyring_data is None else keyring_data))
+        return cls._object(data)
+
+
+class BootSources(ObjectSet, metaclass=BootSourcesType):
+    """The set of boot sources."""
+
+    @classmethod
+    def read(cls):
+        """Get list of `BootSource`'s."""
+        return cls(cls)
+
+
+class BootSourceType(ObjectType):
+
+    def read(cls, id):
+        """Get `BootSource` by `id`."""
+        data = cls._handler.read(id=id)
+        return cls(data)
+
+
+class BootSource(Object, metaclass=BootSourceType):
+    """A boot source."""
+
+    id = ObjectField.Checked(
+        "id", check(int), readonly=True)
+    url = ObjectField.Checked(
+        "url", check(str), check(str))
+    keyring_filename = ObjectField.Checked(
+        "keyring_filename", check(str), check(str), default="")
+    keyring_data = ObjectField.Checked(
+        "keyring_data", check(str), check(str), default="")
+    created = ObjectField.Checked(
+        "created", parse_timestamp, readonly=True)
+    updated = ObjectField.Checked(
+        "updated", parse_timestamp, readonly=True)
+
+    def delete(self):
+        """Delete boot source."""
+        self._handler.delete(id=self.id)

--- a/alburnum/maas/viscera/tests/test_boot_sources.py
+++ b/alburnum/maas/viscera/tests/test_boot_sources.py
@@ -1,0 +1,152 @@
+"""Test for `alburnum.maas.viscera.boot_sources`."""
+
+__all__ = []
+
+import random
+
+from alburnum.maas.testing import (
+    make_name_without_spaces,
+    pick_bool,
+    TestCase,
+)
+from alburnum.maas.viscera.testing import bind
+from testtools.matchers import (
+    Equals,
+    MatchesStructure,
+)
+
+from .. import boot_sources
+
+
+def make_origin():
+    # Create a new origin with BootSources and BootSource. The former refers
+    # to the latter via the origin, hence why it must be bound.
+    return bind(boot_sources.BootSources, boot_sources.BootSource)
+
+
+class TestBootSource(TestCase):
+
+    def test__string_representation_includes_url_keyring_info_only(self):
+        source = boot_sources.BootSource({
+            "url": "http://images.maas.io/ephemeral-v3/daily/",
+            "keyring_filename": (
+                "/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg"),
+            "keyring_data": "",
+        })
+        self.assertThat(repr(source), Equals(
+            "<BootSource keyring_data=%(keyring_data)r "
+            "keyring_filename=%(keyring_filename)r url=%(url)r>" % (
+                source._data)))
+
+
+class TestBootSource(TestCase):
+
+    def test__read(self):
+        source_id = random.randint(0, 100)
+        url = "http://images.maas.io/ephemeral-v3/daily/"
+        keyring_filename = (
+            "/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg")
+
+        BootSource = make_origin().BootSource
+        BootSource._handler.read.return_value = {
+            "id": source_id, "url": url,
+            "keyring_filename": keyring_filename, "keyring_data": ""}
+
+        source = BootSource.read(source_id)
+        BootSource._handler.read.assert_called_once_with(id=source_id)
+        self.assertThat(source, MatchesStructure.byEquality(
+            id=source_id, url=url, keyring_filename=keyring_filename,
+            keyring_data=""))
+
+    def test__delete(self):
+        source_id = random.randint(0, 100)
+
+        BootSource = make_origin().BootSource
+        source = BootSource({
+            "id": source_id,
+            "url": "http://images.maas.io/ephemeral-v3/daily/",
+            "keyring_filename": (
+                "/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg"),
+            "keyring_data": "",
+        })
+
+        source.delete()
+        BootSource._handler.delete.assert_called_once_with(id=source_id)
+
+
+class TestBootSources(TestCase):
+
+    def test__read(self):
+        BootSources = make_origin().BootSources
+        BootSources._handler.read.return_value = [
+            {
+                "id": random.randint(0, 9),
+            },
+            {
+                "id": random.randint(10, 19),
+            },
+        ]
+
+        sources = BootSources.read()
+        self.assertEquals(2, len(sources))
+
+    def test__create_raises_ValueError_when_signed(self):
+        url = "http://images.maas.io/ephemeral-v3/daily/"
+
+        BootSources = make_origin().BootSources
+
+        error = self.assertRaises(ValueError, BootSources.create, url)
+        self.assertEquals(
+            "Either keyring_filename and keyring_data must be set when "
+            "providing a signed source.", str(error))
+
+    def test__create_calls_create_with_keyring_filename(self):
+        source_id = random.randint(0, 100)
+        url = "http://images.maas.io/ephemeral-v3/daily/"
+        keyring_filename = (
+            "/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg")
+
+        BootSources = make_origin().BootSources
+        BootSources._handler.create.return_value = {
+            "id": source_id, "url": url,
+            "keyring_filename": keyring_filename, "keyring_data": ""}
+
+        source = BootSources.create(url, keyring_filename=keyring_filename)
+        BootSources._handler.create.assert_called_once_with(
+            url=url, keyring_filename=keyring_filename, keyring_data="")
+        self.assertThat(source, MatchesStructure.byEquality(
+            id=source_id, url=url,
+            keyring_filename=keyring_filename, keyring_data=""))
+
+    def test__create_calls_create_with_keyring_data(self):
+        source_id = random.randint(0, 100)
+        url = "http://images.maas.io/ephemeral-v3/daily/"
+        keyring_data = make_name_without_spaces("data")
+
+        BootSources = make_origin().BootSources
+        BootSources._handler.create.return_value = {
+            "id": source_id, "url": url,
+            "keyring_filename": "", "keyring_data": keyring_data}
+
+        source = BootSources.create(url, keyring_data=keyring_data)
+        BootSources._handler.create.assert_called_once_with(
+            url=url, keyring_filename="", keyring_data=keyring_data)
+        self.assertThat(source, MatchesStructure.byEquality(
+            id=source_id, url=url,
+            keyring_filename="", keyring_data=keyring_data))
+
+    def test__create_calls_create_with_unsigned_url(self):
+        source_id = random.randint(0, 100)
+        url = "http://images.maas.io/ephemeral-v3/daily/streams/v1/index.json"
+
+        BootSources = make_origin().BootSources
+        BootSources._handler.create.return_value = {
+            "id": source_id, "url": url,
+            "keyring_filename": "", "keyring_data": ""}
+
+        source = BootSources.create(url)
+        BootSources._handler.create.assert_called_once_with(
+            url=url, keyring_filename="", keyring_data="")
+        self.assertThat(source, MatchesStructure.byEquality(
+            id=source_id, url=url,
+            keyring_filename="", keyring_data=""))


### PR DESCRIPTION
Doesn't seem to be a lot of tests for the other modules and not a lot of examples on how to do it correctly. I skipped in it in this branch for now, I used the shell to test that it worked.

The only thing that I could not figure out (as I don't think it exists) is to link selections to a boot source. I would like to do something like:

```
source = origin.BootSource.read(1)
assert type(source.selections[0]) == BootSourceSelection
```