### PR TITLE
remove sub prefix from status_ attributes on Machine as they are no l…

### DIFF
--- a/alburnum/maas/viscera/machines.py
+++ b/alburnum/maas/viscera/machines.py
@@ -135,11 +135,11 @@ class Machine(Object, metaclass=MachineType):
     status = ObjectField.Checked(
         "status", check(int), readonly=True)
     status_action = ObjectField.Checked(
-        "substatus_action", check_optional(str), readonly=True)
+        "status_action", check_optional(str), readonly=True)
     status_message = ObjectField.Checked(
-        "substatus_message", check_optional(str), readonly=True)
+        "status_message", check_optional(str), readonly=True)
     status_name = ObjectField.Checked(
-        "substatus_name", check(str), readonly=True)
+        "status_name", check(str), readonly=True)
 
     # swap_size
 


### PR DESCRIPTION
Probably as a throwback to the 1.0 HTTP API, the status_ attributes of the Machine class expected the corresponding json field to be 'substatus_<something>'

I just removed the 'sub' part for now. I'm not quite sure how to test this, but I'll give it a go if you want.