### PR TITLE
Change the `bind` test helper to return an origin.

### DIFF
--- a/alburnum/maas/viscera/testing.py
+++ b/alburnum/maas/viscera/testing.py
@@ -2,15 +2,45 @@
 
 __all__ = ['bind']
 
+from itertools import chain
+from typing import Mapping
 from unittest.mock import MagicMock
 
+from . import OriginBase
 
-def bind(cls, origin=None, handler=None):
+
+def bind(*objects, session=None):
+    """Bind `objects` into a new `Origin` derived from `session`.
+
+    The origin is constructed using `alburnum.maas.viscera.OriginBase` hence
+    the only other objects that one object may refer to are those given in
+    `objects`. It's exactly like a minimally populated `Origin`.
+
+    If provided, `session` is used when constructing the `OriginBase`
+    instance, otherwise a mock is substituted. This mock has an empty
+    `handlers` mapping.
+
+    :param objects: Any number of `Object` classes, or mappings of `Object`
+        classes from the names with which they should be bound in the origin
+        that's created and returned.
+    :param session: A `bones.SessionAPI` instance.
+    :return: An `OriginBase` instance.
     """
-    Returns a new version of the class that binds the origin
-    and handler of that class with MagicMock (unless you specify otherwise)
-    """
-    return cls.bind(
-        (MagicMock() if origin is None else origin),
-        (MagicMock() if handler is None else handler),
-    )
+    def _flatten_to_items(thing):
+        if isinstance(thing, Mapping):
+            yield from thing.items()
+        else:
+            yield thing.__name__, thing
+
+    objects = map(_flatten_to_items, objects)
+    objects = chain.from_iterable(objects)
+    objects = dict(objects)
+
+    if session is None:
+        session = MagicMock(name="session")
+        session.handlers = {
+            name: MagicMock(name="handler(%s)" % name)
+            for name in objects
+        }
+
+    return OriginBase(session, objects=objects)

--- a/alburnum/maas/viscera/tests/test_machines.py
+++ b/alburnum/maas/viscera/tests/test_machines.py
@@ -16,6 +16,12 @@ from testtools.matchers import Equals
 from .. import machines
 
 
+def make_origin():
+    # Create a new origin with Machines and Machine. The former refers to the
+    # latter via the origin, hence why it must be bound.
+    return bind(machines.Machines, machines.Machine)
+
+
 class TestMachine(TestCase):
 
     def test__string_representation_includes_only_system_id_and_hostname(self):
@@ -28,7 +34,7 @@ class TestMachine(TestCase):
             % machine._data))
 
     def test__deploy(self):
-        Machine = bind(machines.Machine)
+        Machine = make_origin().Machine
         Machine._handler.deploy.return_value = {}
         machine = Machine({
             "system_id": make_name_without_spaces("system-id"),
@@ -48,7 +54,7 @@ class TestMachine(TestCase):
 class TestMachines(TestCase):
 
     def test__allocate(self):
-        Machines = bind(machines.Machines)
+        Machines = make_origin().Machines
         Machines._handler.allocate.return_value = {}
         hostname = make_name_without_spaces("hostname")
         Machines.allocate(


### PR DESCRIPTION
Set-like objects, like Machines or Events, need to refer to the singular type, like Machine or Event. They do so via the origin to which they're bound, so the singular type must be bound to the same session.