### PR TITLE
Add BootSourceSelection and BootSourceSelections.

### DIFF
--- a/alburnum/maas/viscera/__init__.py
+++ b/alburnum/maas/viscera/__init__.py
@@ -179,7 +179,7 @@ class Object(ObjectBasics, metaclass=ObjectType):
 
     __slots__ = "__weakref__", "_data"
 
-    def __init__(self, data):
+    def __init__(self, data, local_data=None):
         super(Object, self).__init__()
         if isinstance(data, Mapping):
             self._data = data
@@ -187,6 +187,13 @@ class Object(ObjectBasics, metaclass=ObjectType):
             raise TypeError(
                 "data must be a mapping, not %s"
                 % type(data).__name__)
+        if local_data is not None:
+            if isinstance(local_data, Mapping):
+                self._data.update(local_data)
+            else:
+                raise TypeError(
+                    "local_data must be a mapping, not %s"
+                    % type(data).__name__)
 
     def __repr__(self, *, name=None, fields=None):
         if name is None:
@@ -586,6 +593,7 @@ class Origin(OriginBase, metaclass=OriginType):
             ".",
             ".account",
             ".boot_sources",
+            ".boot_source_selections",
             ".controllers",
             ".devices",
             ".events",

--- a/alburnum/maas/viscera/boot_source_selections.py
+++ b/alburnum/maas/viscera/boot_source_selections.py
@@ -1,0 +1,103 @@
+"""Objects for boot source selections."""
+
+__all__ = [
+    "BootSource",
+    "BootSources",
+]
+
+from functools import partial
+from typing import List
+
+from . import (
+    check,
+    check_optional,
+    Object,
+    ObjectField,
+    ObjectSet,
+    ObjectType,
+    parse_timestamp,
+)
+from .boot_sources import BootSource
+
+
+class BootSourceSelectionsType(ObjectType):
+    """Metaclass for `BootSourceSelections`."""
+
+    def create(
+            cls, boot_source, os, release, *,
+            arches=None, subarches=None, labels=None):
+        """Create a new `BootSourceSelection`."""
+        if not isinstance(boot_source, BootSource):
+            raise TypeError(
+                "boot_source must be a BootSource, not %s"
+                % type(boot_source).__name__)
+        if arches is None:
+            arches = ['*']
+        if subarches is None:
+            subarches = ['*']
+        if labels is None:
+            labels = ['*']
+        data = cls._handler.create(
+            boot_source_id=boot_source.id,
+            os=os, release=release, arches=arches, subarches=subarches,
+            labels=labels)
+        return cls._object(data, {"boot_source_id": boot_source.id})
+
+
+class BootSourceSelections(ObjectSet, metaclass=BootSourceSelectionsType):
+    """The set of boot source selections."""
+
+    @classmethod
+    def read(cls, boot_source):
+        """Get list of `BootSourceSelection`'s."""
+        if not isinstance(boot_source, BootSource):
+            raise TypeError(
+                "boot_source must be a BootSource, not %s"
+                % type(boot_source).__name__)
+        return cls(map(
+            partial(
+                cls._object,
+                local_data={"boot_source_id": boot_source.id}),
+            cls._handler.read(boot_source_id=boot_source.id)))
+
+
+class BootSourceSelectionType(ObjectType):
+
+    def read(cls, boot_source, id):
+        """Get `BootSourceSelection` by `id`."""
+        if not isinstance(boot_source, BootSource):
+            raise TypeError(
+                "boot_source must be a BootSource, not %s"
+                % type(boot_source).__name__)
+        data = cls._handler.read(boot_source_id=boot_source.id, id=id)
+        return cls(data, {"boot_source_id": boot_source.id})
+
+
+class BootSourceSelection(Object, metaclass=BootSourceSelectionType):
+    """A boot source selection."""
+
+    # Only client-side. Classes in this file place `boot_source_id` on
+    # the object using `local_data`.
+    boot_source_id = ObjectField.Checked(
+        "boot_source_id", check(int), readonly=True)
+
+    id = ObjectField.Checked(
+        "id", check(int), readonly=True)
+    os = ObjectField.Checked(
+        "os", check(str), check(str))
+    release = ObjectField.Checked(
+        "release", check(str), check(str))
+    arches = ObjectField.Checked(
+        "arches", check(List[str]), check(List[str]))
+    subarches = ObjectField.Checked(
+        "subarches", check(List[str]), check(List[str]))
+    labels = ObjectField.Checked(
+        "labels", check(List[str]), check(List[str]))
+
+    def __repr__(self):
+        return super(BootSourceSelection, self).__repr__(
+            fields={"os", "release", "arches", "subarches", "labels"})
+
+    def delete(self):
+        """Delete boot source selection."""
+        self._handler.delete(boot_source_id=self.boot_source_id, id=self.id)

--- a/alburnum/maas/viscera/tests/test_boot_source_selections.py
+++ b/alburnum/maas/viscera/tests/test_boot_source_selections.py
@@ -55,9 +55,6 @@ class TestBootSourceSelection(TestCase):
             "os=%(os)r release=%(release)r subarches=%(subarches)r>" % (
                 selection._data)))
 
-
-class TestBootSourceSelection(TestCase):
-
     def test__read_raises_TypeError_when_no_BootSource(self):
         BootSourceSelection = make_origin().BootSourceSelection
         self.assertRaises(

--- a/alburnum/maas/viscera/tests/test_boot_source_selections.py
+++ b/alburnum/maas/viscera/tests/test_boot_source_selections.py
@@ -1,0 +1,183 @@
+"""Test for `alburnum.maas.viscera.boot_source_selections`."""
+
+__all__ = []
+
+import random
+
+from alburnum.maas.testing import (
+    make_name_without_spaces,
+    pick_bool,
+    TestCase,
+)
+from alburnum.maas.viscera.testing import bind
+from testtools.matchers import (
+    Equals,
+    MatchesStructure,
+)
+
+from .. import boot_sources
+from .. import boot_source_selections
+
+
+def make_origin():
+    # Create a new origin with BootSourceSelections and BootSourceSelection.
+    # The former refers to the latter via the origin, hence why it must be
+    # bound.
+    return bind(
+        boot_source_selections.BootSourceSelections,
+        boot_source_selections.BootSourceSelection)
+
+
+def make_boot_source():
+    return boot_sources.BootSource({
+        "id": random.randint(0, 100),
+        "url": "http://images.maas.io/ephemeral-v3/daily/",
+        "keyring_filename": (
+            "/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg"),
+        "keyring_data": "",
+    })
+
+
+class TestBootSourceSelection(TestCase):
+
+    def test__string_representation_includes_defined_keys(self):
+        selection = boot_source_selections.BootSourceSelection({
+            "os": make_name_without_spaces("os"),
+            "release": make_name_without_spaces("release"),
+            "arches": [make_name_without_spaces("arch")],
+            "subarches": [make_name_without_spaces("subarches")],
+            "labels": [make_name_without_spaces("labels")],
+        }, {
+            "boot_source_id": random.randint(0, 100),
+        })
+        self.assertThat(repr(selection), Equals(
+            "<BootSourceSelection arches=%(arches)r labels=%(labels)r "
+            "os=%(os)r release=%(release)r subarches=%(subarches)r>" % (
+                selection._data)))
+
+
+class TestBootSourceSelection(TestCase):
+
+    def test__read_raises_TypeError_when_no_BootSource(self):
+        BootSourceSelection = make_origin().BootSourceSelection
+        self.assertRaises(
+            TypeError, BootSourceSelection.read,
+            random.randint(0, 100), random.randint(0, 100))
+
+    def test__read(self):
+        source = make_boot_source()
+        selection_id = random.randint(0, 100)
+        os = make_name_without_spaces("os")
+        release = make_name_without_spaces("release")
+        arches = [make_name_without_spaces("arch")]
+        subarches = [make_name_without_spaces("subarches")]
+        labels = [make_name_without_spaces("labels")]
+
+        BootSourceSelection = make_origin().BootSourceSelection
+        BootSourceSelection._handler.read.return_value = {
+            "id": selection_id, "os": os, "release": release,
+            "arches": arches, "subarches": subarches, "labels": labels}
+
+        selection = BootSourceSelection.read(source, selection_id)
+        BootSourceSelection._handler.read.assert_called_once_with(
+            boot_source_id=source.id, id=selection_id)
+        self.assertThat(selection, MatchesStructure.byEquality(
+            id=selection_id, boot_source_id=source.id, os=os, release=release,
+            arches=arches, subarches=subarches, labels=labels))
+
+    def test__delete(self):
+        source = make_boot_source()
+        selection_id = random.randint(0, 100)
+        os = make_name_without_spaces("os")
+        release = make_name_without_spaces("release")
+        arches = [make_name_without_spaces("arch")]
+        subarches = [make_name_without_spaces("subarches")]
+        labels = [make_name_without_spaces("labels")]
+
+        BootSourceSelection = make_origin().BootSourceSelection
+        selection = BootSourceSelection({
+            "id": selection_id, "os": os, "release": release,
+            "arches": arches, "subarches": subarches, "labels": labels}, {
+            "boot_source_id": source.id})
+
+        selection.delete()
+        BootSourceSelection._handler.delete.assert_called_once_with(
+            boot_source_id=source.id, id=selection_id)
+
+
+class TestBootSources(TestCase):
+
+    def test__read_raises_TypeError_when_no_BootSource(self):
+        BootSourceSelections = make_origin().BootSourceSelections
+        self.assertRaises(
+            TypeError, BootSourceSelections.read, random.randint(0, 100))
+
+    def test__read(self):
+        source = make_boot_source()
+        BootSourceSelections = make_origin().BootSourceSelections
+        BootSourceSelections._handler.read.return_value = [
+            {
+                "id": random.randint(0, 9),
+            },
+            {
+                "id": random.randint(10, 19),
+            },
+        ]
+
+        selections = BootSourceSelections.read(source)
+        self.assertEquals(2, len(selections))
+        self.assertEquals(source.id, selections[0].boot_source_id)
+        self.assertEquals(source.id, selections[1].boot_source_id)
+
+    def test__create_raises_TypeError_when_no_BootSource(self):
+        os = make_name_without_spaces("os")
+        release = make_name_without_spaces("release")
+
+        BootSourceSelections = make_origin().BootSourceSelections
+
+        self.assertRaises(
+            TypeError, BootSourceSelections.create,
+            random.randint(0, 100), os, release)
+
+    def test__create__without_kwargs(self):
+        source = make_boot_source()
+        selection_id = random.randint(0, 100)
+        os = make_name_without_spaces("os")
+        release = make_name_without_spaces("release")
+
+        BootSourceSelections = make_origin().BootSourceSelections
+        BootSourceSelections._handler.create.return_value = {
+            "id": selection_id, "os": os, "release": release,
+            "arches": ["*"], "subarches": ["*"], "labels": ["*"]}
+
+        selection = BootSourceSelections.create(source, os, release)
+        BootSourceSelections._handler.create.assert_called_once_with(
+            boot_source_id=source.id, os=os, release=release,
+            arches=["*"], subarches=["*"], labels=["*"])
+        self.assertThat(selection, MatchesStructure.byEquality(
+            id=selection_id, boot_source_id=source.id, os=os, release=release,
+            arches=["*"], subarches=["*"], labels=["*"]))
+
+    def test__create__with_kwargs(self):
+        source = make_boot_source()
+        selection_id = random.randint(0, 100)
+        os = make_name_without_spaces("os")
+        release = make_name_without_spaces("release")
+        arches = [make_name_without_spaces("arch")]
+        subarches = [make_name_without_spaces("subarches")]
+        labels = [make_name_without_spaces("labels")]
+
+        BootSourceSelections = make_origin().BootSourceSelections
+        BootSourceSelections._handler.create.return_value = {
+            "id": selection_id, "os": os, "release": release,
+            "arches": arches, "subarches": subarches, "labels": labels}
+
+        selection = BootSourceSelections.create(
+            source, os, release,
+            arches=arches, subarches=subarches, labels=labels)
+        BootSourceSelections._handler.create.assert_called_once_with(
+            boot_source_id=source.id, os=os, release=release,
+            arches=arches, subarches=subarches, labels=labels)
+        self.assertThat(selection, MatchesStructure.byEquality(
+            id=selection_id, boot_source_id=source.id, os=os, release=release,
+            arches=arches, subarches=subarches, labels=labels))


### PR DESCRIPTION
This still doesn't provide a way to get from a BootSource to a BootSourceSelection easily but this is not to bad and really should be part of the core API.

```
source = BootSource.read(1)
selections = BootSourceSelections.read(source)
```

I would like to see this map some how to:

```
source = BootSource.read(1)
selections = list(source.selections)
````

But that can come later, once we figure out the best way to do that.