### PR TITLE
Change hostname parameter in allocate to name, as per the actual API.…

### DIFF
--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -35,7 +35,7 @@ class MachinesType(ObjectType):
         return cls(cls)
 
     def allocate(
-            cls, *, name: str=None, architecture: str=None,
+            cls, *, hostname: str=None, architecture: str=None,
             cpus: int=None, memory: float=None, tags: Sequence[str]=None):
         """
         :param hostname: The hostname to match.
@@ -47,8 +47,8 @@ class MachinesType(ObjectType):
             associated with a matched machine.
         """
         params = {}
-        if name is not None:
-            params["name"] = name
+        if hostname is not None:
+            params["name"] = hostname
         if architecture is not None:
             params["architecture"] = architecture
         if cpus is not None:

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -35,7 +35,7 @@ class MachinesType(ObjectType):
         return cls(cls)
 
     def allocate(
-            cls, *, hostname: str=None, architecture: str=None,
+            cls, *, name: str=None, architecture: str=None,
             cpus: int=None, memory: float=None, tags: Sequence[str]=None):
         """
         :param hostname: The hostname to match.
@@ -47,8 +47,8 @@ class MachinesType(ObjectType):
             associated with a matched machine.
         """
         params = {}
-        if hostname is not None:
-            params["hostname"] = hostname
+        if name is not None:
+            params["name"] = name
         if architecture is not None:
             params["architecture"] = architecture
         if cpus is not None:

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -57,14 +57,14 @@ class TestMachines(TestCase):
         Machines._handler.allocate.return_value = {}
         hostname = make_name_without_spaces("hostname")
         Machines.allocate(
-            hostname=hostname,
+            name=hostname,
             architecture='amd64/generic',
             cpus=4,
             memory=1024.0,
             tags=['foo', 'bar', '-baz'],
         )
         Machines._handler.allocate.assert_called_once_with(
-            hostname=hostname,
+            name=hostname,
             architecture='amd64/generic',
             cpu_count='4',
             mem='1024.0',

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -57,14 +57,14 @@ class TestMachines(TestCase):
         Machines._handler.allocate.return_value = {}
         hostname = make_name_without_spaces("hostname")
         Machines.allocate(
-            name=hostname,
+            hostname=hostname,
             architecture='amd64/generic',
             cpus=4,
             memory=1024.0,
             tags=['foo', 'bar', '-baz'],
         )
         Machines._handler.allocate.assert_called_once_with(
-            name=hostname,
+            name=hostname,  # API parameter is actually name, not hostname
             architecture='amd64/generic',
             cpu_count='4',
             mem='1024.0',


### PR DESCRIPTION
In the API, the constraint is 'name', not 'hostname' (which is admittedly slightly confusing as in the machine object the field is called hostname)

… Fixes issue #30.